### PR TITLE
0.3.0/crons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN crontab /etc/cron.d/ml-work-cronjob
 COPY src/mnist/main.py /code/
 COPY run.sh /code/run.sh
 
-RUN pip install --no-cache-dir --upgrade git+https://github.com/WhiteCapella/mnist@0.3.0
+RUN pip install --no-cache-dir --upgrade git+https://github.com/WhiteCapella/mnist@0.3.0/crons
 
 CMD ["sh", "run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN crontab /etc/cron.d/ml-work-cronjob
 COPY src/mnist/main.py /code/
 COPY run.sh /code/run.sh
 
-RUN pip install --no-cache-dir --upgrade git+https://github.com/dMario24/mnist.git@0.3.6
+RUN pip install --no-cache-dir --upgrade git+https://github.com/WhiteCapella@0.3.0
 
 CMD ["sh", "run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN crontab /etc/cron.d/ml-work-cronjob
 COPY src/mnist/main.py /code/
 COPY run.sh /code/run.sh
 
-RUN pip install --no-cache-dir --upgrade git+https://github.com/WhiteCapella@0.3.0
+RUN pip install --no-cache-dir --upgrade git+https://github.com/WhiteCapella/mnist@0.3.0
 
 CMD ["sh", "run.sh"]

--- a/ml-work-cronjob
+++ b/ml-work-cronjob
@@ -1,0 +1,1 @@
+* * * * * echo "hi"  >> /var/log/worker.log 2>&1

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c60b4475ba6ea933eba2bf265f62a8573fb1968f32efd37f00186decf8564c01"
+content_hash = "sha256:229df0471635f31d897fd35c08f8fdad8b331e293e5afccfa54c92441ef99042"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -127,6 +127,20 @@ files = [
 ]
 
 [[package]]
+name = "jigeum"
+version = "1.0.2"
+requires_python = ">=3.9"
+summary = "jigeum seoul now"
+groups = ["default"]
+dependencies = [
+    "pytz>=2024.2",
+]
+files = [
+    {file = "jigeum-1.0.2-py3-none-any.whl", hash = "sha256:63d016eeda646effae819f7ec696d235527674c08c75ba6d634216ff30ebd0df"},
+    {file = "jigeum-1.0.2.tar.gz", hash = "sha256:da976a3b90cc956d7e846dc8b25a7e74a9768cddb78def53490c6451b9bdeb42"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.9.2"
 requires_python = ">=3.8"
@@ -199,6 +213,16 @@ groups = ["default"]
 files = [
     {file = "python_multipart-0.0.10-py3-none-any.whl", hash = "sha256:2b06ad9e8d50c7a8db80e3b56dab590137b323410605af2be20d62a5f1ba1dc8"},
     {file = "python_multipart-0.0.10.tar.gz", hash = "sha256:46eb3c6ce6fdda5fb1a03c7e11d490e407c6930a2703fe7aef4da71c374688fa"},
+]
+
+[[package]]
+name = "pytz"
+version = "2024.2"
+summary = "World timezone definitions, modern and historical"
+groups = ["default"]
+files = [
+    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
+    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "uvicorn[standard]>=0.30.6",
     "python-multipart>=0.0.10",
     "PyMySQL>=1.1.1",
+    "jigeum>=1.0.2",
 ]
 requires-python = "==3.11.*"
 readme = "README.md"

--- a/src/mnist/db.py
+++ b/src/mnist/db.py
@@ -1,9 +1,13 @@
 import pymysql.cursors
+import os
 
 def get_conn():
-  conn = pymysql.connect(host='172.18.0.1', port = 53306,
-                            user = 'mnist', password = '1234',
-                            database = 'mnistdb',
+  db_host = os.getenv("DB_IP", "localhost")
+  db_port = os.getenv("DB_PORT", "53306")
+  conn = pymysql.connect(   host=db_host, 
+                            port=int(db_port),
+                            user='mnist', password = '1234',
+                            database='mnistdb',
                             cursorclass=pymysql.cursors.DictCursor)
   return conn
 

--- a/src/mnist/main.py
+++ b/src/mnist/main.py
@@ -30,7 +30,7 @@ async def create_upload_file(file: UploadFile):
     file_ext = file.content_type.split('/')[-1]
 
     # 디렉토리가 없으면 오류, 코드에서 확인 및 만들기 추가
-    upload_dir = "/home/whitecapella/project/mnist/img"
+    upload_dir = "/home/ubuntu/images/n77/"
     if not os.path.exists(upload_dir):
         os.makedirs(upload_dir)
     import uuid
@@ -44,7 +44,7 @@ async def create_upload_file(file: UploadFile):
     
     import jigeum.seoul 
     from mnist.db import dml
-    insert_row = dml(sql, file_name, file_full_path, jigeum.seoul.now(), 'n99')
+    insert_row = dml(sql, file_name, file_full_path, jigeum.seoul.now(), 'n17')
     
     return {
             "filename": file.filename,


### PR DESCRIPTION
## EC2 : 43.202.66.118
## 아래 코드 완성하기
[https://github.com/dMario24/mnist/blob/0.3/cron/src/mnist/worker.py](url)

## crontab 등록 변경
[https://github.com/dMario24/mnist/blob/0.3/cron/ml-work-cronjob](url)

## ml-worker 프로그램 등록
[https://github.com/dMario24/mnist/blob/0.3/cron/pyproject.toml#L30](url)

## 주요 요구사항
[https://github.com/pladata-encore/DE32_101/issues/93#issuecomment-2363039475](url)

## Troubleshooting
### fastapi 서버 uvicorn 이 작업 가상환경 아래에 있는가?
```
$ which uvicorn
/home/diginori/code/mnist/.venv/bin/uvicorn

```

### 조치법
```
$ deactivate
$ pip uninstall uvicorn
$ pip list | grep uvicorn # 없는지 확인
$ source .venv/bin/activate
$ which uvicorn 경로가 가상환경의 경로인지 확인
pyproject.toml 에 아래 설정이 없는 경우 import 에서 오류가 발생 하는 경우가 있음
[tool.pytest.ini_options]
pythonpath = "src"
pyproject.toml 에 아래 설정이 true 이면서 import err 시 pmd install 하면 에러가 해결 되는 경우가 있음
[tool.pdm]
distribution = true
```